### PR TITLE
Replace "Generated" timestamp with exact audio duration (#12)

### DIFF
--- a/Wakeprompt/Models/Alarm.swift
+++ b/Wakeprompt/Models/Alarm.swift
@@ -18,6 +18,7 @@ final class Alarm {
     var repeatDays: [Int]?
     var generatedAudioFilename: String?
     var generatedText: String?
+    var audioDurationSeconds: Double?
     var firedMode: String?
     var lastGeneratedAt: Date?
     var failureReason: String?

--- a/Wakeprompt/Orchestration/AlarmOrchestrator.swift
+++ b/Wakeprompt/Orchestration/AlarmOrchestrator.swift
@@ -106,6 +106,7 @@ final class AlarmOrchestrator {
             _ = try audioFileManager.saveAudio(data: audioData, filename: filename)
             alarm.generatedAudioFilename = filename
             alarm.lastGeneratedAt = Date()
+            alarm.audioDurationSeconds = try? audioFileManager.audioDuration(filename: filename)
 
             try await backbone.scheduleAlarm(
                 id: alarmId,
@@ -167,6 +168,7 @@ final class AlarmOrchestrator {
         alarm.state = .draft
         alarm.generatedText = nil
         alarm.generatedAudioFilename = nil
+        alarm.audioDurationSeconds = nil
         alarm.failureReason = nil
         alarm.firedMode = nil
         trySave(context)

--- a/Wakeprompt/Services/AudioFileManager.swift
+++ b/Wakeprompt/Services/AudioFileManager.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 enum AudioFileError: Error, LocalizedError {
@@ -55,6 +56,13 @@ final class AudioFileManager: Sendable {
         guard let dir = try? librarySoundsURL() else { return false }
         let fileURL = dir.appendingPathComponent(filename)
         return FileManager.default.fileExists(atPath: fileURL.path)
+    }
+
+    func audioDuration(filename: String) throws -> Double {
+        let dir = try librarySoundsURL()
+        let fileURL = dir.appendingPathComponent(filename)
+        let file = try AVAudioFile(forReading: fileURL)
+        return Double(file.length) / file.processingFormat.sampleRate
     }
 
     static func filename(for alarmId: UUID) -> String {

--- a/Wakeprompt/Views/AlarmDetailView.swift
+++ b/Wakeprompt/Views/AlarmDetailView.swift
@@ -137,7 +137,7 @@ struct AlarmDetailView: View {
     }
 
     private func formatDuration(_ seconds: Double) -> String {
-        let total = Int(seconds)
+        let total = Int(seconds.rounded())
         let mins = total / 60
         let secs = total % 60
         return mins > 0 ? String(format: "%d:%02d", mins, secs) : "\(secs)s"

--- a/Wakeprompt/Views/AlarmDetailView.swift
+++ b/Wakeprompt/Views/AlarmDetailView.swift
@@ -81,9 +81,9 @@ struct AlarmDetailView: View {
                     LabeledContent("Fallback Reason", value: reason)
                 }
 
-                if let lastGen = alarm.lastGeneratedAt {
-                    LabeledContent("Generated") {
-                        Text(lastGen, format: .dateTime.hour().minute())
+                if let duration = alarm.audioDurationSeconds {
+                    LabeledContent("Audio Duration") {
+                        Text(formatDuration(duration))
                     }
                 }
             }
@@ -134,6 +134,13 @@ struct AlarmDetailView: View {
         let trimmed = promptText.trimmingCharacters(in: .whitespacesAndNewlines)
         alarm.prompt = trimmed.isEmpty ? nil : trimmed
         regenerate()
+    }
+
+    private func formatDuration(_ seconds: Double) -> String {
+        let total = Int(seconds)
+        let mins = total / 60
+        let secs = total % 60
+        return mins > 0 ? String(format: "%d:%02d", mins, secs) : "\(secs)s"
     }
 
     private func regenerate() {


### PR DESCRIPTION
Read WAV duration via AVAudioFile after saving to disk; display
in alarm detail instead of the generation timestamp.

https://claude.ai/code/session_01RtBwz7ktiE7NKqRovVoMnM