### PR TITLE
Guard against re-arming an already-armed alarm (#10)

### DIFF
--- a/Wakeprompt/Orchestration/AlarmOrchestrator.swift
+++ b/Wakeprompt/Orchestration/AlarmOrchestrator.swift
@@ -31,6 +31,8 @@ final class AlarmOrchestrator {
     func saveAlarm(_ alarm: Alarm, context: ModelContext) async {
         let alarmId = alarm.id
 
+        guard alarm.state != .armed else { return }
+
         telemetry.log(.alarmCreated, alarmId: alarmId)
 
         // Step 1: Validate API key


### PR DESCRIPTION
Early return from saveAlarm if the alarm is already in .armed state, preventing duplicate AlarmKit schedules.

https://claude.ai/code/session_01RtBwz7ktiE7NKqRovVoMnM